### PR TITLE
fix(#49): metadata 타입 jsonb로 변경

### DIFF
--- a/ai-engine/src/models/document.py
+++ b/ai-engine/src/models/document.py
@@ -1,5 +1,6 @@
-from sqlalchemy import Column, Integer, Text, String, JSON, DateTime, BigInteger
+from sqlalchemy import Column, Integer, Text, String, DateTime, BigInteger
 from sqlalchemy.sql import func
+from sqlalchemy.dialects.postgresql import JSONB
 from pgvector.sqlalchemy import Vector
 from src.models.base import Base
 
@@ -37,7 +38,7 @@ class DocumentChunk(Base):
     trace_id = Column(String(100), nullable=True) 
     
     # 추가 정보를 위한 확장 필드 (예: 카테고리 태그, 제목 등)
-    metadata_json = Column(JSON, nullable=True)
+    metadata_json = Column(JSONB, nullable=True)
     
     # 레코드 생성 시각 (시간 순서에 따른 계보 시각화 기준선)
     created_at = Column(DateTime(timezone=True), server_default=func.now())


### PR DESCRIPTION
src/services/memory.py (출처 계보 추출 및 저장)

역할: AI가 답변을 마친 후, 이번 추론에 인용되었던 조상 채팅방 ID 목록(source_session_ids)을 동적으로 긁어모아 피드백 루프 기억을 저장할 때 메타데이터 장부 주머니에 낙인(Lineage Tracking)으로 함께 묶어 적재합니다.

src/models/document.py (바이너리 고속 JSONB 승격)

역할: metadata_json 컬럼의 타입을 generic JSON에서 PostgreSQL 전용 고성능 규격인 JSONB 타입으로 전격 승격시켜, 쿼리 단에서 하부 내장 가속 메서드들을 한계 없이 호출할 수 있는 완벽한 기초 공사를 마쳤습니다.

src/services/vector_service.py (GIN 인덱스 기반 2차 유출 가드)

역할: or_(~has_key, ~contains) 구조의 최신 SQLAlchemy 표준 ORM 문법을 체결했습니다. 이로 인해 메타데이터에 키가 없는 순수 일반 지식 청크의 증발을 원천 방어함과 동시에, 차단된 방의 피를 이어받은 2차 파생 기억들만 PostgreSQL GIN 인덱스를 태워 초고속으로 솎아내는 최종 집행 서킷을 완성했습니다.